### PR TITLE
relax the constraints, base 4.10 works just fine (fixes #5)

### DIFF
--- a/th-printf.cabal
+++ b/th-printf.cabal
@@ -14,7 +14,7 @@ cabal-version:       >=1.10
 library
   hs-source-dirs:      src
   exposed-modules:     Text.Printf.TH
-  build-depends:       base <4.10
+  build-depends:       base <4.11
                      , attoparsec
                      , bytestring
                      , template-haskell


### PR DESCRIPTION
Everything works fine with base 4.10/ghc8.2.2, so relax the constraint.

I hope you can make a new release with the fix. If you have no time, I can upload it myself to hackage if you give me the rights. Thanks!