### PR TITLE
Add an `st` quasiquoter for generating strict `Text`

### DIFF
--- a/src/Language/Haskell/Printf.hs
+++ b/src/Language/Haskell/Printf.hs
@@ -20,6 +20,7 @@ your input must be an instance of "Bounded".
 module Language.Haskell.Printf (
   s,
   t,
+  st,
   p,
   hp,
 ) where
@@ -75,6 +76,12 @@ s = quoter $ \s' -> do
 t :: QuasiQuoter
 t = quoter $ \s' -> do
   (lhss, rhs) <- toSplices s' OutputText
+  return $ LamE lhss rhs
+
+-- | Behaves identically to 's', but produces strict 'Data.Text.Text'.
+st :: QuasiQuoter
+st = quoter $ \s' -> do
+  (lhss, rhs) <- toSplices s' OutputStrictText
   return $ LamE lhss rhs
 
 {- | Like 's', but prints the resulting string to @stdout@.

--- a/src/Language/Haskell/Printf/Lib.hs
+++ b/src/Language/Haskell/Printf/Lib.hs
@@ -21,6 +21,7 @@ import Language.Haskell.TH.Syntax
 import Buf (
   SizedBuilder,
   SizedStr,
+  SizedStrictBuilder,
   finalize,
  )
 import Control.Monad (mapAndUnzipM)
@@ -30,7 +31,7 @@ import Parser.Types hiding (
   width,
  )
 
-data OutputType = OutputString | OutputText
+data OutputType = OutputString | OutputText | OutputStrictText
   deriving (Show, Eq, Ord, Generic, Enum, Bounded)
 
 {- | Takes a format string as input and produces a tuple @(args, outputExpr)@.
@@ -57,6 +58,7 @@ toSplices s' ot = case parseStr s' of
   otype = case ot of
     OutputString -> [t|SizedStr|]
     OutputText -> [t|SizedBuilder|]
+    OutputStrictText -> [t|SizedStrictBuilder|]
 
 extractExpr :: Atom -> Q ([Name], ExpQ)
 extractExpr (Str s') = return ([], [|fromString $(stringE s')|])


### PR DESCRIPTION
Very cool package!  I found myself wanting a quasiquoter that generated *strict* `Text` as well as lazy `Text`, so I added one – I hope you find it useful :-)